### PR TITLE
Migrate GitHub Actions workflows to Node 24 (INF-2948)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       GH_DEBUG: api
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fetch all history
           filter: tree:0  # "Treeless clones" filter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `actions/checkout` from v4 to v5 in `.github/workflows/release.yaml`.
- Confirmed the only workflow `uses:` reference is `actions/checkout@v4` before this change.
- Confirmed `actions/checkout@v5` declares `runs.using: node24` and its v5 release notes identify the Node 24 runtime update.

## Testing
- Parsed `.github/workflows/release.yaml` with a temporary top-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` env setting and confirmed the workflow still loads with `actions/checkout@v5`.
- Removed the temporary env setting after validation.
- Parsed the final workflow YAML after removing the temporary env setting.
- Ran `git diff --check`.

## Notes
- No `meitner-se/actions/*`, `actions/setup-go`, `actions/upload-artifact`, `actions/cache`, or other third-party action references are present.
- GitHub reported no PR checks for this branch; the only workflow is configured for `push` to `main`, so a branch/PR Actions trial run was not available without changing workflow trigger behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-2948](https://linear.app/meitner-se/issue/INF-2948/migrate-github-actions-workflows-from-node-20-to-node-24)

<div><a href="https://cursor.com/agents/bc-620ea1df-e5f9-4e2f-a9d4-4275915aa162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-620ea1df-e5f9-4e2f-a9d4-4275915aa162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

